### PR TITLE
Add generator script and CSV sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.log
+extrator_telefone_empresas/empresas_com_telefone.xlsx
+extrator_telefone_empresas/.env
+extrator_telefone_empresas/empresas.xlsx

--- a/extrator_telefone_empresas/README.md
+++ b/extrator_telefone_empresas/README.md
@@ -1,0 +1,46 @@
+# Extrator de Telefone de Empresas
+
+Aplicação em Python para ler uma planilha de empresas, buscar automaticamente o número de telefone de cada uma na internet e salvar o resultado em nova planilha.
+
+## Instalação
+
+```bash
+pip install -r requirements.txt
+```
+
+Configure a chave da SerpAPI em um arquivo `.env`:
+
+```bash
+SERPAPI_KEY=xxxxxx
+```
+
+## Geração da planilha de exemplo
+
+Este repositório inclui o arquivo `empresas.csv` com dados fictícios para testes. Caso deseje gerar a planilha Excel a partir desse CSV, execute:
+
+```bash
+python gerar_planilha_exemplo.py
+```
+
+O script criará `empresas.xlsx` que é usada como entrada padrão da aplicação.
+
+## Uso
+
+Depois de gerar a planilha (ou fornecer a sua própria), execute o script principal:
+
+```bash
+python main.py
+```
+
+Será gerado o arquivo `empresas_com_telefone.xlsx` com a coluna `Telefone Encontrado` preenchida quando possível.
+
+## Testes
+
+```bash
+pytest
+```
+
+## Exemplo de entrada e saída
+
+- `empresas.csv`: arquivo de exemplo utilizado para gerar a planilha Excel.
+- `empresas_com_telefone.xlsx`: planilha gerada após a execução.

--- a/extrator_telefone_empresas/empresas.csv
+++ b/extrator_telefone_empresas/empresas.csv
@@ -1,0 +1,4 @@
+Nome da Empresa,CNPJ,Razao Social,Regiao
+Padaria Real,12.345.678/0001-90,Padaria Real Ltda,Sudeste
+Oficina do Joao,98.765.432/0001-10,Oficina Mecanica Joao,Sul
+Restaurante Bom Gosto,11.222.333/0001-00,Bom Gosto Refeicoes ME,Nordeste

--- a/extrator_telefone_empresas/extrator/__init__.py
+++ b/extrator_telefone_empresas/extrator/__init__.py
@@ -1,0 +1,15 @@
+"""Módulo de extração de telefones de empresas."""
+
+from .leitor_planilha import ler_planilha
+from .buscador_telefone import buscar_telefone
+from .extrator_regex import extrair_telefone
+from .gravador_planilha import salvar_planilha
+from .logger import setup_logger
+
+__all__ = [
+    "ler_planilha",
+    "buscar_telefone",
+    "extrair_telefone",
+    "salvar_planilha",
+    "setup_logger",
+]

--- a/extrator_telefone_empresas/extrator/buscador_telefone.py
+++ b/extrator_telefone_empresas/extrator/buscador_telefone.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from .logger import setup_logger
+from .extrator_regex import extrair_telefone
+
+logger = setup_logger(__name__)
+load_dotenv()
+
+SERPAPI_URL = "https://serpapi.com/search.json"
+
+
+def buscar_telefone(nome: str, regiao: str) -> Optional[str]:
+    """Busca o telefone de uma empresa utilizando a SerpAPI."""
+    api_key = os.getenv("SERPAPI_KEY")
+    if not api_key:
+        logger.warning("SERPAPI_KEY não configurada")
+        return None
+
+    query = f"telefone empresa {nome} {regiao}"
+    params = {
+        "engine": "google",
+        "q": query,
+        "hl": "pt",
+        "gl": "br",
+        "api_key": api_key,
+    }
+
+    time.sleep(random.uniform(5, 10))
+    try:
+        resp = requests.get(SERPAPI_URL, params=params, timeout=20)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Erro na requisição para SerpAPI: %s", exc)
+        return None
+
+    try:
+        data = resp.json()
+    except ValueError:
+        logger.error("Resposta inválida da SerpAPI")
+        return None
+
+    # Verifica snippets nos resultados orgânicos
+    for result in data.get("organic_results", []):
+        snippet = result.get("snippet") or ""
+        telefone = extrair_telefone(snippet)
+        if telefone:
+            logger.info("Telefone encontrado via snippet para %s: %s", nome, telefone)
+            return telefone
+
+    # Verifica caixa de respostas
+    answer_box = data.get("answer_box") or {}
+    if isinstance(answer_box, dict):
+        for value in answer_box.values():
+            if isinstance(value, str):
+                telefone = extrair_telefone(value)
+                if telefone:
+                    logger.info(
+                        "Telefone encontrado via answer_box para %s: %s", nome, telefone
+                    )
+                    return telefone
+
+    logger.info("Telefone não encontrado para %s", nome)
+    return None

--- a/extrator_telefone_empresas/extrator/extrator_regex.py
+++ b/extrator_telefone_empresas/extrator/extrator_regex.py
@@ -1,0 +1,14 @@
+import re
+from typing import Optional
+
+TELEFONE_REGEX = re.compile(r"\(?\d{2}\)?[\s-]?\d{4,5}-?\d{4}")
+
+
+def extrair_telefone(texto: str) -> Optional[str]:
+    """Extrai o primeiro telefone válido de um texto."""
+    if not texto:
+        return None
+    match = TELEFONE_REGEX.search(texto)
+    if match:
+        return match.group()
+    return None

--- a/extrator_telefone_empresas/extrator/gravador_planilha.py
+++ b/extrator_telefone_empresas/extrator/gravador_planilha.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pandas import DataFrame
+
+from .logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def salvar_planilha(df: DataFrame, caminho: str) -> None:
+    """Salva o DataFrame em uma planilha Excel."""
+    try:
+        df.to_excel(caminho, sheet_name="Empresas", index=False)
+        logger.info("Planilha salva em %s", caminho)
+    except Exception as exc:
+        logger.error("Erro ao salvar planilha: %s", exc)
+        raise
+
+    sem_telefone = df[df["Telefone Encontrado"].isna()]
+    if not sem_telefone.empty:
+        with open("empresas_sem_telefone.log", "w", encoding="utf-8") as f:
+            for nome in sem_telefone["Nome da Empresa"]:
+                f.write(f"{nome}\n")
+        logger.info("%d empresas sem telefone", len(sem_telefone))

--- a/extrator_telefone_empresas/extrator/leitor_planilha.py
+++ b/extrator_telefone_empresas/extrator/leitor_planilha.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pandas as pd
+from pandas import DataFrame
+from .logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+COLUNAS_OBRIGATORIAS = [
+    "Nome da Empresa",
+    "CNPJ",
+    "Razão Social",
+    "Região",
+]
+
+
+def ler_planilha(caminho: str) -> DataFrame:
+    """Lê a planilha e retorna um DataFrame validado."""
+    try:
+        df = pd.read_excel(caminho, sheet_name="Empresas")
+    except Exception as exc:
+        logger.error("Erro ao ler planilha: %s", exc)
+        raise
+
+    faltantes = [col for col in COLUNAS_OBRIGATORIAS if col not in df.columns]
+    if faltantes:
+        raise ValueError(f"Colunas obrigatórias ausentes: {faltantes}")
+
+    df = df.drop_duplicates(subset=["CNPJ"]).reset_index(drop=True)
+    df["Telefone Encontrado"] = None
+    logger.info("Planilha '%s' lida com %d registros", caminho, len(df))
+    return df

--- a/extrator_telefone_empresas/extrator/logger.py
+++ b/extrator_telefone_empresas/extrator/logger.py
@@ -1,0 +1,26 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+
+def setup_logger(name: str) -> logging.Logger:
+    """Configura e retorna um logger."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+
+    # Handler para terminal
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    # Handler para arquivo rotativo
+    file_handler = RotatingFileHandler("extrator.log", maxBytes=1000000, backupCount=3)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    return logger

--- a/extrator_telefone_empresas/gerar_planilha_exemplo.py
+++ b/extrator_telefone_empresas/gerar_planilha_exemplo.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+def gerar_excel() -> None:
+    """Gera empresas.xlsx a partir do arquivo CSV."""
+    df = pd.read_csv('empresas.csv')
+    df.to_excel('empresas.xlsx', sheet_name='Empresas', index=False)
+
+
+if __name__ == '__main__':
+    gerar_excel()

--- a/extrator_telefone_empresas/main.py
+++ b/extrator_telefone_empresas/main.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from tqdm import tqdm
+
+from extrator import ler_planilha, buscar_telefone, salvar_planilha, setup_logger
+
+logger = setup_logger("main")
+
+
+def main() -> None:
+    entrada = "empresas.xlsx"
+    saida = "empresas_com_telefone.xlsx"
+
+    if not os.path.exists(entrada):
+        logger.error("Arquivo %s não encontrado", entrada)
+        return
+
+    df = ler_planilha(entrada)
+
+    for idx, row in tqdm(df.iterrows(), total=len(df), desc="Buscando telefones"):
+        nome = row["Nome da Empresa"]
+        regiao = row["Região"]
+        telefone = buscar_telefone(nome, regiao)
+        if telefone:
+            df.at[idx, "Telefone Encontrado"] = telefone
+
+    salvar_planilha(df, saida)
+
+
+if __name__ == "__main__":
+    main()

--- a/extrator_telefone_empresas/requirements.txt
+++ b/extrator_telefone_empresas/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+openpyxl
+requests
+beautifulsoup4
+python-dotenv
+tqdm
+pytest

--- a/extrator_telefone_empresas/testes/test_buscador_telefone.py
+++ b/extrator_telefone_empresas/testes/test_buscador_telefone.py
@@ -1,0 +1,21 @@
+import requests
+from unittest.mock import patch
+
+from extrator.buscador_telefone import buscar_telefone
+
+
+def test_buscar_telefone_sem_chave(monkeypatch):
+    monkeypatch.delenv("SERPAPI_KEY", raising=False)
+    # evita sleep desnecessario
+    with patch("extrator.buscador_telefone.time.sleep"):
+        resultado = buscar_telefone("Empresa X", "Sul")
+    assert resultado is None
+
+
+def test_buscar_telefone_erro_requisicao(monkeypatch):
+    monkeypatch.setenv("SERPAPI_KEY", "dummy")
+    with patch("extrator.buscador_telefone.requests.get") as mock_get, \
+         patch("extrator.buscador_telefone.time.sleep"):
+        mock_get.side_effect = requests.RequestException()
+        resultado = buscar_telefone("Empresa Y", "Norte")
+    assert resultado is None

--- a/extrator_telefone_empresas/testes/test_extrator_regex.py
+++ b/extrator_telefone_empresas/testes/test_extrator_regex.py
@@ -1,0 +1,19 @@
+import pytest
+
+from extrator.extrator_regex import extrair_telefone
+
+
+@pytest.mark.parametrize(
+    "texto,esperado",
+    [
+        ("Ligue para (11) 98765-4321 agora", "(11) 98765-4321"),
+        ("Telefone: 11987654321", "11987654321"),
+        ("Contato 11 3456-7890 adicional", "11 3456-7890"),
+    ],
+)
+def test_extrair_telefone_valido(texto, esperado):
+    assert extrair_telefone(texto) == esperado
+
+
+def test_extrair_telefone_invalido():
+    assert extrair_telefone("Sem número aqui") is None

--- a/extrator_telefone_empresas/testes/test_leitor_planilha.py
+++ b/extrator_telefone_empresas/testes/test_leitor_planilha.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from extrator.leitor_planilha import ler_planilha
+
+
+def criar_planilha_temporaria(tmp_path):
+    dados = {
+        "Nome da Empresa": ["A", "B", "A"],
+        "CNPJ": ["1", "2", "1"],
+        "Razão Social": ["A SA", "B SA", "A SA"],
+        "Região": ["X", "Y", "X"],
+    }
+    df = pd.DataFrame(dados)
+    caminho = tmp_path / "empresas.xlsx"
+    with pd.ExcelWriter(caminho, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name="Empresas", index=False)
+    return caminho
+
+
+def test_ler_planilha(tmp_path):
+    caminho = criar_planilha_temporaria(tmp_path)
+    df = ler_planilha(caminho)
+
+    assert list(df.columns) == [
+        "Nome da Empresa",
+        "CNPJ",
+        "Razão Social",
+        "Região",
+        "Telefone Encontrado",
+    ]
+    assert len(df) == 2  # removeu duplicata pelo CNPJ


### PR DESCRIPTION
## Summary
- replace sample Excel with a text-based CSV
- add script to generate `empresas.xlsx` from the CSV
- document using the CSV and generator in README
- ignore generated Excel files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b83c1ea48327b0777f5ba84ff8eb